### PR TITLE
Remove reference to summer

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,6 +1,6 @@
 - 1:
   title: "Rails Girls Summer of Code"
-  text: "Rails Girls Summer of Code funds women around the world to work full-time over summer on open-source software projects."
+  text: "Rails Girls Summer of Code funds women and non-binary people around the world to work full-time on open source software projects in July-September."
   image: "/images/rebrand/rgsoc.png"
   link: "/projects/rgsoc/"
 - 2:


### PR DESCRIPTION
Remove reference to summer in 'summer of code' to include people in the southern hemisphere (project runs July-Sept)