### PR TITLE
Hide grants page

### DIFF
--- a/grants.html
+++ b/grants.html
@@ -1,3 +1,5 @@
+<!--
+
 ---
 title: Open Source Grants
 layout: project
@@ -46,3 +48,5 @@ maintainers (or core contributors) to work on their projects full time.</p>
     </div>
   </div>
 </article>
+
+-->

--- a/grants.html
+++ b/grants.html
@@ -1,9 +1,6 @@
 <!--
-
----
 title: Open Source Grants
 layout: project
----
 
 
 <article>
@@ -47,6 +44,4 @@ maintainers (or core contributors) to work on their projects full time.</p>
       </section>
     </div>
   </div>
-</article>
-
--->
+</article> -->


### PR DESCRIPTION
People contacting Foundation after finding page via Internet search but not a currently active project.
Hide until project reopens.